### PR TITLE
fix: reuse wg client

### DIFF
--- a/quick/status.go
+++ b/quick/status.go
@@ -5,13 +5,18 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
-func PeerStatus(iface string) (map[wgtypes.Key]*wgtypes.Peer, error) {
-	c, err := wgctrl.New()
-	defer c.Close()
+var client *wgctrl.Client
+
+func init() {
+	var err error
+	client, err = wgctrl.New()
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
-	device, err := c.Device(iface)
+}
+
+func PeerStatus(iface string) (map[wgtypes.Key]*wgtypes.Peer, error) {
+	device, err := client.Device(iface)
 	if err != nil {
 		return nil, err
 	}

--- a/quick/wg.go
+++ b/quick/wg.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
-	"golang.zx2c4.com/wireguard/wgctrl"
 )
 
 // Up sets and configures the wg interface. Mostly equivalent to `wg-quick up iface`
@@ -157,13 +156,7 @@ func Sync(cfg *Config, iface string, logger logrus.FieldLogger) error {
 
 // SyncWireguardDevice synces wireguard vpn setting on the given link. It does not set routes/addresses beyond wg internal crypto-key routing, only handles wireguard specific settings
 func SyncWireguardDevice(cfg *Config, link netlink.Link, log logrus.FieldLogger) error {
-	cl, err := wgctrl.New()
-	defer cl.Close()
-	if err != nil {
-		log.WithError(err).Errorln("cannot setup wireguard device")
-		return err
-	}
-	if err := cl.ConfigureDevice(link.Attrs().Name, cfg.Config); err != nil {
+	if err := client.ConfigureDevice(link.Attrs().Name, cfg.Config); err != nil {
 		log.WithError(err).Error("cannot configure device")
 		return err
 	}


### PR DESCRIPTION
复用wgclient

15个wg隧道，启动30分钟后内存占用对比，内存占用减小约82%

优化后：
![1369f8f796ef1938b434db321a5ef62c](https://github.com/BaiMeow/wg-quick-op/assets/86180691/ca12d73e-9c34-4004-be8b-2985e51157f1)

优化前：
![aede5e2941bdd301c6b906a37609b9bd](https://github.com/BaiMeow/wg-quick-op/assets/86180691/1f06da21-ea23-452e-80a6-25a70820dd06)

没搞懂为什么client close了还会占内存